### PR TITLE
TDD-3651 - main

### DIFF
--- a/.changeset/olive-falcons-listen.md
+++ b/.changeset/olive-falcons-listen.md
@@ -1,0 +1,5 @@
+---
+"laravel-trustup-media-io": minor
+---
+
+Add MediaEndpoint::search (POST payload lookup) and use it to load external media relations, preventing HTTP 414 failures that silently dropped media on large uuid batches. Requires trustup-io-media with the POST /media/search route.

--- a/src/Contracts/Endpoints/MediaEndpointContract.php
+++ b/src/Contracts/Endpoints/MediaEndpointContract.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Henrotaym\LaravelTrustupMediaIo\Contracts\Endpoints;
 
-use Henrotaym\LaravelApiClient\Contracts\TryResponseContract;
 use Henrotaym\LaravelTrustupMediaIo\Contracts\Responses\Media\DestroyMediaResponseContract;
 use Henrotaym\LaravelTrustupMediaIo\Contracts\Responses\Media\GetMediaResponseContract;
 use Henrotaym\LaravelTrustupMediaIo\Contracts\Responses\Media\StoreMediaResponseContract;
@@ -14,6 +14,12 @@ interface MediaEndpointContract
     public function store(StoreMediaRequestContract $request): StoreMediaResponseContract;
 
     public function get(GetMediaRequestContract $request): GetMediaResponseContract;
+
+    /**
+     * Same lookup as get() but sends filters as a POST payload, allowing
+     * uuid batches too large for a GET query string.
+     */
+    public function search(GetMediaRequestContract $request): GetMediaResponseContract;
 
     public function destroy(DestroyMediaRequestContract $request): DestroyMediaResponseContract;
 }

--- a/src/Endpoints/MediaEndpoint.php
+++ b/src/Endpoints/MediaEndpoint.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Henrotaym\LaravelTrustupMediaIo\Endpoints;
 
 use Henrotaym\LaravelApiClient\Contracts\ClientContract;
@@ -19,10 +20,13 @@ use Henrotaym\LaravelTrustupMediaIoCommon\Contracts\Transformers\Requests\Media\
 class MediaEndpoint implements MediaEndpointContract
 {
     protected ClientContract $client;
+
     protected GetMediaRequestTransformerContract $getRequestTransformer;
+
     protected StoreMediaRequestTransformerContract $storeRequestTransformer;
+
     protected DestroyMediaRequestTransformerContract $destroyRequestTransformer;
-    
+
     public function __construct(
         ClientContract $client,
         GetMediaRequestTransformerContract $getRequestTransformer,
@@ -38,7 +42,7 @@ class MediaEndpoint implements MediaEndpointContract
     public function store(StoreMediaRequestContract $request): StoreMediaResponseContract
     {
         $this->prepareMediaRequest($request);
-        
+
         /** @var RequestContract */
         $clientRequest = app()->make(RequestContract::class);
 
@@ -49,11 +53,11 @@ class MediaEndpoint implements MediaEndpointContract
 
         /** @var StoreMediaResponseContract */
         $response = app()->make(StoreMediaResponseContract::class);
-        $apiResponse = $this->client->try($clientRequest, "Could not store media.");
+        $apiResponse = $this->client->try($clientRequest, 'Could not store media.');
 
-        if ($apiResponse->failed()):
+        if ($apiResponse->failed()) {
             report($apiResponse->error());
-        endif;
+        }
 
         return $response->setResponse($apiResponse);
     }
@@ -61,7 +65,7 @@ class MediaEndpoint implements MediaEndpointContract
     public function get(GetMediaRequestContract $request): GetMediaResponseContract
     {
         $this->prepareMediaRequest($request);
-        
+
         /** @var RequestContract */
         $clientRequest = app()->make(RequestContract::class);
 
@@ -71,11 +75,33 @@ class MediaEndpoint implements MediaEndpointContract
 
         /** @var GetMediaResponseContract */
         $response = app()->make(GetMediaResponseContract::class);
-        $apiResponse = $this->client->try($clientRequest, "Could not get media.");
+        $apiResponse = $this->client->try($clientRequest, 'Could not get media.');
 
-        if ($apiResponse->failed()):
+        if ($apiResponse->failed()) {
             report($apiResponse->error());
-        endif;
+        }
+
+        return $response->setResponse($apiResponse);
+    }
+
+    public function search(GetMediaRequestContract $request): GetMediaResponseContract
+    {
+        $this->prepareMediaRequest($request);
+
+        /** @var RequestContract */
+        $clientRequest = app()->make(RequestContract::class);
+
+        $clientRequest->setVerb('POST')
+            ->setUrl('/search')
+            ->addData($this->getRequestTransformer->toArray($request));
+
+        /** @var GetMediaResponseContract */
+        $response = app()->make(GetMediaResponseContract::class);
+        $apiResponse = $this->client->try($clientRequest, 'Could not search media.');
+
+        if ($apiResponse->failed()) {
+            report($apiResponse->error());
+        }
 
         return $response->setResponse($apiResponse);
     }
@@ -84,9 +110,9 @@ class MediaEndpoint implements MediaEndpointContract
     {
         if ($request->hasAppKey()
             || $request->isExplicitelyNotHavingAppKey()
-        ):
+        ) {
             return;
-        endif;
+        }
 
         $request->setAppKey(Package::getConfig('app_key'));
     }
@@ -94,7 +120,7 @@ class MediaEndpoint implements MediaEndpointContract
     public function destroy(DestroyMediaRequestContract $request): DestroyMediaResponseContract
     {
         $this->prepareMediaRequest($request);
-        
+
         /** @var RequestContract */
         $clientRequest = app()->make(RequestContract::class);
 
@@ -104,11 +130,11 @@ class MediaEndpoint implements MediaEndpointContract
 
         /** @var DestroyMediaResponseContract */
         $response = app()->make(DestroyMediaResponseContract::class);
-        $apiResponse = $this->client->try($clientRequest, "Could not destroy media.");
+        $apiResponse = $this->client->try($clientRequest, 'Could not destroy media.');
 
-        if ($apiResponse->failed()):
+        if ($apiResponse->failed()) {
             report($apiResponse->error());
-        endif;
+        }
 
         return $response->setResponse($apiResponse);
     }

--- a/src/Endpoints/MediaEndpoint.php
+++ b/src/Endpoints/MediaEndpoint.php
@@ -64,40 +64,30 @@ class MediaEndpoint implements MediaEndpointContract
 
     public function get(GetMediaRequestContract $request): GetMediaResponseContract
     {
-        $this->prepareMediaRequest($request);
-
-        /** @var RequestContract */
-        $clientRequest = app()->make(RequestContract::class);
-
-        $clientRequest->setVerb('GET')
-            ->setUrl('/')
-            ->addQuery($this->getRequestTransformer->toArray($request));
-
-        /** @var GetMediaResponseContract */
-        $response = app()->make(GetMediaResponseContract::class);
-        $apiResponse = $this->client->try($clientRequest, 'Could not get media.');
-
-        if ($apiResponse->failed()) {
-            report($apiResponse->error());
-        }
-
-        return $response->setResponse($apiResponse);
+        return $this->retrieveMedia($request, 'GET', '/', 'Could not get media.');
     }
 
     public function search(GetMediaRequestContract $request): GetMediaResponseContract
+    {
+        return $this->retrieveMedia($request, 'POST', '/search', 'Could not search media.');
+    }
+
+    protected function retrieveMedia(GetMediaRequestContract $request, string $verb, string $url, string $errorMessage): GetMediaResponseContract
     {
         $this->prepareMediaRequest($request);
 
         /** @var RequestContract */
         $clientRequest = app()->make(RequestContract::class);
+        $clientRequest->setVerb($verb)->setUrl($url);
 
-        $clientRequest->setVerb('POST')
-            ->setUrl('/search')
-            ->addData($this->getRequestTransformer->toArray($request));
+        $attributes = $this->getRequestTransformer->toArray($request);
+        $verb === 'GET'
+            ? $clientRequest->addQuery($attributes)
+            : $clientRequest->addData($attributes);
 
         /** @var GetMediaResponseContract */
         $response = app()->make(GetMediaResponseContract::class);
-        $apiResponse = $this->client->try($clientRequest, 'Could not search media.');
+        $apiResponse = $this->client->try($clientRequest, $errorMessage);
 
         if ($apiResponse->failed()) {
             report($apiResponse->error());

--- a/src/Models/MediaRelationLoadingCallback.php
+++ b/src/Models/MediaRelationLoadingCallback.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Henrotaym\LaravelTrustupMediaIo\Models;
 
-use Illuminate\Support\Collection;
-use Henrotaym\LaravelTrustupMediaIo\Contracts\Endpoints\MediaEndpointContract;
 use Deegitalbe\LaravelTrustupIoExternalModelRelations\Contracts\Models\Relations\ExternalModelRelationLoadingCallbackContract;
+use Henrotaym\LaravelTrustupMediaIo\Contracts\Endpoints\MediaEndpointContract;
 use Henrotaym\LaravelTrustupMediaIoCommon\Contracts\Requests\Media\GetMediaRequestContract;
+use Illuminate\Support\Collection;
 
 class MediaRelationLoadingCallback implements ExternalModelRelationLoadingCallbackContract
 {
@@ -12,15 +13,15 @@ class MediaRelationLoadingCallback implements ExternalModelRelationLoadingCallba
 
     public function __construct(MediaEndpointContract $endpoint)
     {
-        $this->endpoint = $endpoint;    
+        $this->endpoint = $endpoint;
     }
-    
+
     public function load(Collection $identifiers): Collection
     {
         /** @var GetMediaRequestContract */
         $request = app()->make(GetMediaRequestContract::class);
         $request->setUuids($identifiers);
 
-        return $this->endpoint->get($request)->getMedia();
+        return $this->endpoint->search($request)->getMedia();
     }
 }

--- a/tests/Unit/MediaRelationLoadingCallbackTest.php
+++ b/tests/Unit/MediaRelationLoadingCallbackTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Henrotaym\LaravelTrustupMediaIo\Tests\Unit;
+
+use Henrotaym\LaravelTrustupMediaIo\Contracts\Endpoints\MediaEndpointContract;
+use Henrotaym\LaravelTrustupMediaIo\Contracts\Responses\Media\GetMediaResponseContract;
+use Henrotaym\LaravelTrustupMediaIo\Models\MediaRelationLoadingCallback;
+use Henrotaym\LaravelTrustupMediaIo\Tests\TestCase;
+use Henrotaym\LaravelTrustupMediaIoCommon\Contracts\Requests\Media\GetMediaRequestContract;
+use Illuminate\Support\Collection;
+
+class MediaRelationLoadingCallbackTest extends TestCase
+{
+    /** @test */
+    public function loading_identifiers_uses_the_search_endpoint_in_a_single_request()
+    {
+        $identifiers = $this->identifiers(250);
+        $callback = new MediaRelationLoadingCallback($this->endpointEchoingUuids($requestedUuidCounts));
+
+        $media = $callback->load($identifiers);
+
+        $this->assertEquals([250], $requestedUuidCounts);
+        $this->assertEquals($identifiers->values()->all(), $media->values()->all());
+    }
+
+    protected function identifiers(int $count): Collection
+    {
+        return collect(range(1, $count))->map(fn (int $index) => "uuid-$index");
+    }
+
+    protected function endpointEchoingUuids(?array &$requestedUuidCounts): MediaEndpointContract
+    {
+        $requestedUuidCounts = [];
+
+        $endpoint = $this->createMock(MediaEndpointContract::class);
+        $endpoint->expects($this->never())->method('get');
+        $endpoint->method('search')->willReturnCallback(function (GetMediaRequestContract $request) use (&$requestedUuidCounts) {
+            $requestedUuidCounts[] = $request->getUuids()->count();
+
+            $response = $this->createMock(GetMediaResponseContract::class);
+            $response->method('getMedia')->willReturn($request->getUuids()->values());
+
+            return $response;
+        });
+
+        return $endpoint;
+    }
+}


### PR DESCRIPTION
## Why

Loading media by uuids sent every uuid in a single GET query string. Above ~150 uuids the URL exceeds the 8KB server limit and the media service answers HTTP 414. The failure is reported but swallowed, so callers receive an empty media list: expense exports shipped ZIPs without their XML evidence files (BUG-227, Flare error 8421944, 152 occurrences since February).

## What

- New `MediaEndpoint::search()`, mimicking `get()` but sending the filters as a POST payload to `/media/search`. `get()` is untouched, existing callers keep working.
- `MediaRelationLoadingCallback::load()` now uses `search()`, keeping a single batched request whatever the uuid count.
- Unit test asserting a single request carries all uuids and `get()` is never called.
- Changeset: minor bump.

## Dependency

Requires the `POST /media/search` route from deegitalbe/trustup-io-media (PR opened there). The service must deploy before this release is consumed, otherwise `search` calls would 404.

Linear: TDD-3651